### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npx elm-test "src/**/*Tests.elm" // runs all tests in glob
 ```
 
 ## Perf testing
-I created some quick performance tests in IdleGame/PerfTesting/. They were created to demonstrate how long calculating Time Passes would take after the player returned after various lengths of time. Each test varies the length of time and the "tick duration" to see what can be satisfactory. The tests all pass autoamtically, the true test is how long the test takes to run. Of course, this isn't necessarily reproducible across different machines, or representative of user hardware and results, but it's close enough to make some rough comparisons.
+I created some quick performance tests in IdleGame/PerfTesting/. They were created to demonstrate how long calculating Time Passes would take after the player returned after various lengths of time. Each test varies the length of time and the "tick duration" to see what can be satisfactory. The tests all pass automatically, the true test is how long the test takes to run. Of course, this isn't necessarily reproducible across different machines, or representative of user hardware and results, but it's close enough to make some rough comparisons.
 
 ```
 npx elm-test src/IdleGame/PerfTesting/Test60Days.elm


### PR DESCRIPTION
## Summary
- fix minor typo in README `Perf testing` section

## Testing
- `npm test` *(fails: Missing script)*
- `npx elm-test` *(fails: The tests/ directory does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685444bcba588333888c586b56d75630