### PR TITLE
Add basic e2e helpers

### DIFF
--- a/e2e/basic.spec.ts
+++ b/e2e/basic.spec.ts
@@ -1,6 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { test } from '@playwright/test';
+import { createAndEnterGame, navigateToTab, startActivity } from './utils';
 
-test("shows Games text", async ({ page }) => {
-  await page.goto("http://localhost:8000");
-  await expect(page.getByText("Games")).toBeVisible();
+test('start Gather Sage', async ({ page }) => {
+  await createAndEnterGame(page);
+  await navigateToTab(page, 'Herb Gathering');
+  await startActivity(page, 'Gather Sage');
 });

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,0 +1,31 @@
+import { Page, expect } from '@playwright/test';
+
+export async function createAndEnterGame(page: Page) {
+  await page.goto('http://localhost:8000');
+  await page.getByRole('button', { name: 'New Game' }).click();
+  await page.getByRole('button', { name: 'Game 1' }).click();
+  await expect(
+    page.getByRole('navigation').getByText('Home')
+  ).toBeVisible();
+}
+
+export async function navigateToTab(page: Page, tabName: string) {
+  // Drawer control is a label acting as a button.
+  const drawerToggle = page
+    .getByRole('navigation')
+    .locator('label.drawer-button[for="drawer"]');
+  if (await drawerToggle.isVisible()) {
+    await drawerToggle.click();
+  }
+  await page.getByText(tabName).click();
+  await expect(
+    page.getByRole('navigation').getByText(tabName)
+  ).toBeVisible();
+}
+
+export async function startActivity(page: Page, activityName: string) {
+  await page.getByRole('heading', { level: 2, name: activityName }).first().click();
+  await expect(
+    page.getByRole('heading', { level: 2, name: activityName }).nth(1)
+  ).toBeVisible();
+}


### PR DESCRIPTION
## Summary
- add test utilities for Playwright e2e suite
- replace sample spec with happy path test using helpers

## Testing
- `lamdera make src/Frontend.elm src/Backend.elm`
- `npx playwright test --reporter=line`

------
https://chatgpt.com/codex/tasks/task_e_68547908db5c8333a1aa3a20dcc4aa20